### PR TITLE
Updates useQuery and createUseQueryOptions to reflect undefined returned from queryFn

### DIFF
--- a/packages/connect-query/src/create-query-service.test.tsx
+++ b/packages/connect-query/src/create-query-service.test.tsx
@@ -110,7 +110,7 @@ describe('createQueryService', () => {
             context?:
               | QueryFunctionContext<ConnectQueryKey<SayRequest>>
               | undefined,
-          ) => Promise<SayResponse>
+          ) => Promise<SayResponse | undefined>
         >
       >;
       expect(queryOptions).toHaveProperty('queryFn', expect.any(Function));

--- a/packages/connect-query/src/unary-hooks.test.ts
+++ b/packages/connect-query/src/unary-hooks.test.ts
@@ -214,7 +214,7 @@ describe('unaryHooks', () => {
               context?:
                 | QueryFunctionContext<ConnectQueryKey<CountRequest>>
                 | undefined,
-            ) => Promise<CountResponse>;
+            ) => Promise<CountResponse | undefined>;
             placeholderData?: () => CountResponse | undefined;
             onError?: (error: ConnectError) => void;
           }

--- a/packages/connect-query/src/unary-hooks.test.ts
+++ b/packages/connect-query/src/unary-hooks.test.ts
@@ -963,7 +963,7 @@ describe('unaryHooks', () => {
             queryKey: ConnectQueryKey<SayRequest>;
             queryFn: (
               context?: QueryFunctionContext<ConnectQueryKey<SayRequest>>,
-            ) => Promise<SayResponse>;
+            ) => Promise<SayResponse | undefined>;
             placeholderData?: () => SayResponse | undefined;
             onError?: (error: ConnectError) => void;
           }
@@ -1175,7 +1175,7 @@ describe('unaryHooks', () => {
               context?:
                 | QueryFunctionContext<ConnectQueryKey<SayRequest>>
                 | undefined,
-            ) => Promise<SayResponse>
+            ) => Promise<SayResponse | undefined>
           >
         >;
       });
@@ -1203,7 +1203,7 @@ describe('unaryHooks', () => {
         const { result } = renderHook(() => say.useQuery(input), wrapper());
 
         const response = await result.current.queryFn();
-        expect(response.toJson()).toStrictEqual(hardcodedResponse);
+        expect(response?.toJson()).toStrictEqual(hardcodedResponse);
         // we need to encode to an ArrayBuffer here because of an implementation detail in Connect-ES that doesn't use JSON body, even in JSON encoding mode
         const body = new TextEncoder().encode(JSON.stringify(input));
         expect(globalThis.fetch).toHaveBeenCalledWith(

--- a/packages/connect-query/src/unary-hooks.ts
+++ b/packages/connect-query/src/unary-hooks.ts
@@ -67,7 +67,9 @@ export interface UnaryHooks<I extends Message<I>, O extends Message<O>> {
   ) => {
     enabled: boolean;
     queryKey: ConnectQueryKey<I>;
-    queryFn: (context?: QueryFunctionContext<ConnectQueryKey<I>>) => Promise<O>;
+    queryFn: (
+      context?: QueryFunctionContext<ConnectQueryKey<I>>,
+    ) => Promise<O | undefined>;
     placeholderData?: () => O | undefined;
     onError?: (error: ConnectError) => void;
   };

--- a/packages/connect-query/src/unary-hooks.ts
+++ b/packages/connect-query/src/unary-hooks.ts
@@ -159,7 +159,9 @@ export interface UnaryHooks<I extends Message<I>, O extends Message<O>> {
   ) => {
     enabled: boolean;
     queryKey: ConnectQueryKey<I>;
-    queryFn: (context?: QueryFunctionContext<ConnectQueryKey<I>>) => Promise<O>;
+    queryFn: (
+      context?: QueryFunctionContext<ConnectQueryKey<I>>,
+    ) => Promise<O | undefined>;
     placeholderData?: () => O | undefined;
     onError?: (error: ConnectError) => void;
   };


### PR DESCRIPTION
closes https://github.com/bufbuild/connect-query/issues/29

(I have written some tests but they're not included here because they'll need to come after https://github.com/bufbuild/connect-query/pull/34)