### PR TITLE
Compile both commonjs + esm

### DIFF
--- a/packages/connect-query/jest-environment-jsdom.js
+++ b/packages/connect-query/jest-environment-jsdom.js
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const { TextDecoder, TextEncoder } = require('util');
+import { TextDecoder, TextEncoder } from 'util';
 
-const JsdomEnvironment = require('jest-environment-jsdom').default;
+import { TestEnvironment } from 'jest-environment-jsdom';
 
 // This test environment is needed because, as of 0.8.1, the Connect-ES codebase will not work in the jsdom environment due to a lack of TextEncoder and Text Decoder
-class CustomJsdomEnvironment extends JsdomEnvironment {
+class CustomJsdomEnvironment extends TestEnvironment {
   // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility -- it works and I'm not playing with it.
   async setup() {
     await super.setup();
@@ -38,4 +38,4 @@ class CustomJsdomEnvironment extends JsdomEnvironment {
   }
 }
 
-module.exports = CustomJsdomEnvironment;
+export default CustomJsdomEnvironment;

--- a/packages/connect-query/jest-environment-jsdom.js
+++ b/packages/connect-query/jest-environment-jsdom.js
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TextDecoder, TextEncoder } from 'util';
-
 import { TestEnvironment } from 'jest-environment-jsdom';
+import { TextDecoder, TextEncoder } from 'util';
 
 // This test environment is needed because, as of 0.8.1, the Connect-ES codebase will not work in the jsdom environment due to a lack of TextEncoder and Text Decoder
 class CustomJsdomEnvironment extends TestEnvironment {

--- a/packages/connect-query/package.json
+++ b/packages/connect-query/package.json
@@ -8,6 +8,14 @@
   ],
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/bufbuild/connect-query.git",

--- a/packages/connect-query/package.json
+++ b/packages/connect-query/package.json
@@ -6,14 +6,15 @@
   "files": [
     "dist/**"
   ],
+  "type": "module",
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "repository": {

--- a/packages/connect-query/tsup.config.ts
+++ b/packages/connect-query/tsup.config.ts
@@ -20,4 +20,5 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
+  format: ['cjs', 'esm'],
 });


### PR DESCRIPTION
Convert all outputs to module by default and export commonjs as secondary.

Fixes #54 