### PR TITLE
Use corepack to guarantee pnpm version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,16 +20,19 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
+      # Slightly fragile since it runs on the default node version
+      # but until setup-node supports corepack (https://github.com/actions/setup-node/issues/531)
+      # this is our best option
+      - name: Enable core pack
+        run: |
+          corepack enable
+          pnpm --version
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          pnpm --version
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,17 +20,16 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 7
-          run_install: false
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+
+      - name: Enable corepack
+        run: |
+          corepack enable
+          pnpm --version
 
       - name: Install dependencies
         run: pnpm install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing
 
+## Making sure your on the right pnpm version
+
+Ensure that you've got corepack enabled:
+
+```console
+corepack enable
+```
+
+This should only be necessary once.
+
+Verify that `pnpm --version` matches the `packageManager` version in `package.json`.
+
 ## Updating dependencies
 
 You can update all dependencies in this project with a single command:

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -28,7 +28,8 @@
     "tanstack",
     "todos",
     "tsdoc",
-    "tsup"
+    "tsup",
+    "corepack"
   ],
   "ignorePaths": ["**/*.svg", "**/*.ai", "**/pnpm-lock.yaml", "*.excalidraw"]
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
   "engines": {
     "node": ">=16",
     "npm": ">=8"
-  }
+  },
+  "packageManager": "pnpm@7.33.0"
 }


### PR DESCRIPTION
Using corepack should ensure that the correct versions are used.